### PR TITLE
Port to Frida 17 and add keywords for PackageManager discovery

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,6 +5,9 @@
  * Frida, primarily used for Android.
  *
  */
+
+import Java from 'frida-java-bridge';
+
 export class Stack {
     private threadObj!: Java.Wrapper<object>;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,28 @@
 {
-  "name": "frida-stacks",
+  "name": "frida-stack",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "frida-stacks",
+      "name": "frida-stack",
       "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frida-java-bridge": "^7.0.2"
+      },
       "devDependencies": {
-        "@types/frida-gum": "^18.5.1",
+        "@types/frida-gum": "^19.0.0",
         "@types/node": "^18.19.3",
         "typescript": "^5.3.3"
       }
     },
     "node_modules/@types/frida-gum": {
-      "version": "18.7.0",
-      "resolved": "https://registry.npmjs.org/@types/frida-gum/-/frida-gum-18.7.0.tgz",
-      "integrity": "sha512-HhBomXE23fLDAWXEKi3BjJLrlH9wAv9IEQNfO/PaYHQNNbh0Bi06gx6JbXTspVpbqlbVqkWAuU7n6HaS9B6yXA==",
-      "dev": true
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/@types/frida-gum/-/frida-gum-19.0.0.tgz",
+      "integrity": "sha512-qViK1KwvPEAkajwSUv0wpZvZLiX8xO4JFFCh8dfYZfzSyOEfoE0KliCP/nJSKIKG6N3hXnPowrvPufjs5fLKAA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "18.19.34",
@@ -27,6 +32,12 @@
       "dependencies": {
         "undici-types": "~5.26.4"
       }
+    },
+    "node_modules/frida-java-bridge": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/frida-java-bridge/-/frida-java-bridge-7.0.2.tgz",
+      "integrity": "sha512-tIw10Jw5kRJfSnFGd1XXwCWs1QF9H55O6vWFt4QOZd2t/anUKks0sbEoPJG3FLL+AVVAK6DW1VFxjJDyvp9tQA==",
+      "license": "LGPL-2.0 WITH WxWindows-exception-3.1"
     },
     "node_modules/typescript": {
       "version": "5.4.5",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "frida-stack",
   "version": "1.0.0",
   "description": "Getting better stacks and backtraces in Frida",
+  "keywords": [
+    "frida-gum"
+  ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -26,8 +26,11 @@
     "watch": "tsc -w"
   },
   "devDependencies": {
-    "@types/frida-gum": "^18.5.1",
+    "@types/frida-gum": "^19.0.0",
     "@types/node": "^18.19.3",
     "typescript": "^5.3.3"
+  },
+  "dependencies": {
+    "frida-java-bridge": "^7.0.2"
   }
 }


### PR DESCRIPTION
:wave: About to introduce the `Frida.PackageManager` API, which uses npm as its backend. The idea is to streamline the process for new users so Node.js + npm aren't needed, and make it easy to discover bridges and other libraries written for frida-gum's JavaScript runtime. The goal is just the bare minimum for searching and installing packages, power-users should still be using the `npm` CLI.

The `Frida.PackageManager.search()` API will surface packages with the `frida-gum` keyword, and will also support specifying a category that it ANDs into the query, to list only bridges for example.